### PR TITLE
requirements.txt bug fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ keras==2.1.5
 opencv-python==3.4.0.12
 scikit-image==0.13.1
 matplotlib==2.1.2
-tqdm=4.28.1
+tqdm==4.28.1


### PR DESCRIPTION
2. Install requirements:
pip install -r requirements.txt
It is failing because of a missing "=".
Added it in this request.